### PR TITLE
Default unit to "1" if not provided

### DIFF
--- a/lib/format_value.js
+++ b/lib/format_value.js
@@ -28,7 +28,11 @@ const formatters = {
     let [ , amount, approximation, unit ] = value.match(patterns.quantity)
     amount = parseFloat(amount)
     const valueObj = { amount }
-    if (unit) valueObj.unit = unit.replace('U', 'Q')
+    if (unit) {
+      valueObj.unit = unit.replace('U', 'Q')
+    } else {
+      valueObj.unit = '1'
+    }
     if (approximation != null) {
       approximation = parseFloat(approximation.slice(1))
       valueObj.lowerBound = amount - approximation


### PR DESCRIPTION
If QuickStatements command involves a `quantity` and `unit` is not provided, quickstatements-to-wikibase-edit returns a value object without a `unit` property. This causes an error in wikibase-edit's `datatype_tests.js` because it expects that if a value object is provided, it should have a `unit` property.